### PR TITLE
Bcz/port to python2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 dist/
 caneton.egg-info/
 __pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Caneton
 =======
 
-Python 3 project under BSD license to decode messages (or frames) from a CAN bus.
+Python 2/3 project under BSD license to decode messages (or frames) from a CAN bus.
 
 DBC in JSON
 -----------
@@ -42,4 +42,4 @@ Tests
 
 To run the unit tests:
 
-`$ python3 -m unittest`
+`$ nosetests`

--- a/caneton/__init__.py
+++ b/caneton/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Polyconseil SAS
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/caneton/cli.py
+++ b/caneton/cli.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-#
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Polyconseil SAS
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/caneton/compat.py
+++ b/caneton/compat.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2015 Polyconseil SAS
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+import sys
+
+PY_VERSION = sys.version_info[0]
+
+IS_PY3 = PY_VERSION == 3
+IS_PY2 = not IS_PY3
+
+
+def int_from_bytes(data, byteorder, signed=False):
+    """Convert bytes to an integer
+
+    Args:
+        data: bytes, the bytes to convert
+        byteorder: 'big' or 'little', indicates the endianness
+        signed: indicates whether two’s complement is used to represent the integer.
+
+    """
+    if IS_PY3:
+        return int.from_bytes(data, byteorder, signed)
+
+    if byteorder == 'big':
+        data = bytearray(reversed(data))
+    if isinstance(data, str):
+        data = bytearray(data)
+    num = 0
+    for offset, byte in enumerate(data):
+        num += byte << (offset * 8)
+    if signed and (data[-1] & 0x80):
+        num = num - (2 ** (len(data) * 8))
+    return num

--- a/caneton/compat.py
+++ b/caneton/compat.py
@@ -23,6 +23,8 @@ def int_from_bytes(data, byteorder, signed=False):
     if IS_PY3:
         return int.from_bytes(data, byteorder, signed)
 
+    if not len(data):
+        return 0
     if byteorder == 'big':
         data = bytearray(reversed(data))
     if isinstance(data, str):

--- a/caneton/decode.py
+++ b/caneton/decode.py
@@ -1,8 +1,11 @@
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Polyconseil SAS
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
+from . import compat
 from . import exceptions
+
 
 MESSAGE_MAX_LENGTH = 8
 
@@ -144,11 +147,11 @@ def message_decode(message_id, message_length, message_data, dbc_json):
     # Motorola
     # 0n to fit in n characters width with 0 padding (can't use bin())
     # [2:] to remove '0b' prefix and zfill constant length with 0 padding
-    message_binary_msb = bin(int.from_bytes(message_data, 'big'))[2:].zfill(
+    message_binary_msb = bin(compat.int_from_bytes(message_data, 'big'))[2:].zfill(
         message_binary_length)
 
     # For Intel, identical but swapped
-    message_binary_lsb = bin(int.from_bytes(message_data, 'little'))[2:].zfill(
+    message_binary_lsb = bin(compat.int_from_bytes(message_data, 'little'))[2:].zfill(
         message_binary_length)
 
     if message_info.get('has_multiplexor', False):

--- a/caneton/exceptions.py
+++ b/caneton/exceptions.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Polyconseil SAS
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/caneton/version.py
+++ b/caneton/version.py
@@ -1,1 +1,2 @@
+# -*- coding: utf-8 -*-
 VERSION = '1.0.7'

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # Copyright (c) Polyconseil SAS. All rights reserved.
 
 from setuptools import find_packages, setup
@@ -25,6 +25,7 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Natural Language :: English",
+        "Programming Language :: Python :: 2 :: 7",
         "Programming Language :: Python :: 3",
     ],
     test_suite='',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Polyconseil SAS
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2015 Polyconseil SAS
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+from unittest import TestCase
+
+import caneton.compat
+
+
+class CompatTestCase(TestCase):
+
+    def test_from_bytes(self):
+        self.assertEqual(caneton.compat.int_from_bytes(b'\x00\x10', byteorder='big'), 16)
+
+    def test_from_bytes_little_endian(self):
+        self.assertEqual(caneton.compat.int_from_bytes(b'\x00\x10', byteorder='little'), 4096)
+
+    def test_int_from_bytes_negative(self):
+        self.assertEqual(caneton.compat.int_from_bytes(b'\xfc\x00', byteorder='big', signed=True), -1024)
+
+    def test_int_from_bytes_signed(self):
+        self.assertEqual(caneton.compat.int_from_bytes(b'\xfc\x00', byteorder='big', signed=False), 64512)
+
+    def test_int_from_bytes_iterable(self):
+        self.assertEqual(caneton.compat.int_from_bytes([255, 0, 0], byteorder='big'), 16711680)

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -24,3 +24,104 @@ class CompatTestCase(TestCase):
 
     def test_int_from_bytes_iterable(self):
         self.assertEqual(caneton.compat.int_from_bytes([255, 0, 0], byteorder='big'), 16711680)
+
+    def test_from_bytes_cpython(self):
+        # test suite taken from cpython code
+        # https://hg.python.org/cpython/file/3.4/Lib/test/test_long.py#l1075
+
+        def check(tests, byteorder, signed=False):
+            for test, expected in tests.items():
+                try:
+                    self.assertEqual(
+                        caneton.compat.int_from_bytes(test, byteorder, signed=signed),
+                        expected
+                    )
+                except Exception:
+                    raise AssertionError(
+                        "failed to convert {0} with byteorder={1!r} and signed={2}"
+                        .format(test, byteorder, signed)
+                    )
+
+        # Convert signed big-endian byte arrays to integers.
+        tests1 = {
+            b'': 0,
+            b'\x00': 0,
+            b'\x00\x00': 0,
+            b'\x01': 1,
+            b'\x00\x01': 1,
+            b'\xff': -1,
+            b'\xff\xff': -1,
+            b'\x81': -127,
+            b'\x80': -128,
+            b'\xff\x7f': -129,
+            b'\x7f': 127,
+            b'\x00\x81': 129,
+            b'\xff\x01': -255,
+            b'\xff\x00': -256,
+            b'\x00\xff': 255,
+            b'\x01\x00': 256,
+            b'\x7f\xff': 32767,
+            b'\x80\x00': -32768,
+            b'\x00\xff\xff': 65535,
+            b'\xff\x00\x00': -65536,
+            b'\x80\x00\x00': -8388608
+        }
+        check(tests1, 'big', signed=True)
+
+        # Convert signed little-endian byte arrays to integers.
+        tests2 = {
+            b'': 0,
+            b'\x00': 0,
+            b'\x00\x00': 0,
+            b'\x01': 1,
+            b'\x00\x01': 256,
+            b'\xff': -1,
+            b'\xff\xff': -1,
+            b'\x81': -127,
+            b'\x80': -128,
+            b'\x7f\xff': -129,
+            b'\x7f': 127,
+            b'\x81\x00': 129,
+            b'\x01\xff': -255,
+            b'\x00\xff': -256,
+            b'\xff\x00': 255,
+            b'\x00\x01': 256,
+            b'\xff\x7f': 32767,
+            b'\x00\x80': -32768,
+            b'\xff\xff\x00': 65535,
+            b'\x00\x00\xff': -65536,
+            b'\x00\x00\x80': -8388608
+        }
+        check(tests2, 'little', signed=True)
+
+        # Convert unsigned big-endian byte arrays to integers.
+        tests3 = {
+            b'': 0,
+            b'\x00': 0,
+            b'\x01': 1,
+            b'\x7f': 127,
+            b'\x80': 128,
+            b'\xff': 255,
+            b'\x01\x00': 256,
+            b'\x7f\xff': 32767,
+            b'\x80\x00': 32768,
+            b'\xff\xff': 65535,
+            b'\x01\x00\x00': 65536,
+        }
+        check(tests3, 'big', signed=False)
+
+        # Convert integers to unsigned little-endian byte arrays.
+        tests4 = {
+            b'': 0,
+            b'\x00': 0,
+            b'\x01': 1,
+            b'\x7f': 127,
+            b'\x80': 128,
+            b'\xff': 255,
+            b'\x00\x01': 256,
+            b'\xff\x7f': 32767,
+            b'\x00\x80': 32768,
+            b'\xff\xff': 65535,
+            b'\x00\x00\x01': 65536,
+        }
+        check(tests4, 'little', signed=False)

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright © 2015 Polyconseil SAS
 # SPDX-License-Identifier: BSD-3-Clause
 #


### PR DESCRIPTION
Hi @sra,

here is a first step into porting caneton to python2.

I had some troubles to port the test `test_message_wo_signals` since the given bytes value has a length of 7, which makes struct.pack fail.
Do I need to pad the value ?
